### PR TITLE
docsy: switch to go modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/DGEXSolutions/osrd-docsy

--- a/README.md
+++ b/README.md
@@ -11,29 +11,7 @@ It's free and open-source forever!
 
 ## Clone
 
-`git clone --recurse-submodules --shallow-submodules git@github.com:DGEXSolutions/osrd-website.git`
-
-**This repository uses submodules. Please read the following carefuly**
-
-If you forgot `--recurse-submodules --shallow-submodules` at clone time, run:
-
-`git submodule update --init --recursive --depth=1`
-
-## Using submodules
-
-If you made some changes in the theme repository, you have to update the submodule:
-
-`git submodule update --remote --depth=1`
-
-If somebody already commited the submodule update, either pull with the proper submodule update flag:
-
-`git pull -r --recurse-submodules`
-
-or update the submodule after the fact:
-
-`git submodule update`
-
-Otherwise, the submodule folder will not be updated.
+`git clone git@github.com:DGEXSolutions/osrd-website.git`
 
 ## Build instructions
 

--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ enableMissingTranslationPlaceholders = true
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+# theme = ["docsy"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = false
@@ -214,3 +214,19 @@ enable = false
   url = "https://example.org/mail"
   icon = "fa fa-envelope"
   desc = "Discuss development issues around the project"
+
+
+# hugo module configuration
+
+[module]
+  # uncomment line below for temporary local development of module
+  # replacements = "github.com/google/docsy -> ../../docsy"
+  [module.hugoVersion]
+    extended = true
+    min = "0.75.0"
+  [[module.imports]]
+    path = "github.com/google/docsy"
+    disable = false
+  [[module.imports]]
+    path = "github.com/google/docsy/dependencies"
+    disable = false

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/google/docsy-example
+
+go 1.13
+
+require (
+	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
+	github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 // indirect
+	github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 // indirect
+	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
+)
+

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 h1:+vc8wn8oOlLhjUOTvP6ljXuIi03HZWb9jWc4ZhVrO9g=
+github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
+github.com/google/docsy/dependencies v0.2.0-pre/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 h1:EKYx2OlWxo2HBhZ+dWzZbufBfh+qMKmz2K1lf1GJmto=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
+github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Docsy changed its submodule workflow. There are two possible outcomes:
 - stick with the submodule workflow, which now requires npm installing the theme
 - switch to the go module workflow, which this PR implements