### PR TITLE
Update the simulation model

### DIFF
--- a/content/developers/internals/simulation-model/_index.md
+++ b/content/developers/internals/simulation-model/_index.md
@@ -5,8 +5,14 @@ weight: 20
 description: Décrit le fonctionnement du poste d'aiguillage virtuel et de la signalisation
 ---
 
+{{% pageinfo color="info" %}}
+Ce document est une description du modèle de fonctionnement cible d'OSRD.
+Il a pour objectif de renseigner développeurs et experts métiers sur le fonctionnement du simulateur.
+Des changements y sont apportés au fil de l'évolution du projet.
+{{% /pageinfo %}}
+
 {{% pageinfo color="warning" %}}
-Ce modèle n'est pas finalisé, et en attente d'implémentation
+Ce modèle est en cours d'implémentation
 {{% /pageinfo %}}
 
 ## Architecture
@@ -54,7 +60,13 @@ flowchart TD
     click movable-elements href "./movable-elements/" _self
 ```
 
-## TODO
+{{% alert title="Pistes d'évolution" color="info" %}}
+- Gestion des overlaps
+{{% /alert %}}
 
-- overlaps
-- opposing movement protection
+## Remerciements
+
+Par ordre alphabétique:
+
+- Christophe Mémin
+- Nathanaël Dias

--- a/content/developers/internals/simulation-model/location.md
+++ b/content/developers/internals/simulation-model/location.md
@@ -7,20 +7,25 @@ description: "Fournit les informations de position des trains sur le réseau"
 
 ## Description
 
-La couche de localisation suit le déplacement des trains dans l'infrastructure
+La couche de localisation permet à d'autres modules de simulation de suivre le déplacement du train dans l'infrastructure.
+L'infrastructure ferroviaire est découpée en régions appelées zones. Quand on train entre dans une zone, ce module permet d'en être notifié.
 
-## Dépendances
+Les zones (ou TVDSection / DetectionSection) sont des partitions physiques des voies :
 
-- une liste de zones
-
-## Opérations
-
-- Occuper une zone
-- Libérer une zone
-- Observer les changements d'occupation d'une zone
+- capables de détecter la présence d'un train
 
 ## Exigences de conception
 
 - il doit être possible de suivre les changements d'occupation d'une zone
 - il _devra_ être possible de suivre les déplacements d'un train
 - il _devra_ être possible d'implémenter un système de bloc mobile
+
+## Dépendances
+
+- `statique` une liste de zones
+
+## Opérations
+
+- Occuper une zone
+- Libérer une zone
+- Observer les changements d'occupation d'une zone

--- a/content/developers/internals/simulation-model/movable-elements.md
+++ b/content/developers/internals/simulation-model/movable-elements.md
@@ -12,8 +12,8 @@ Ces états sont mutuellement exclusifs.
 
 ## Dépendances
 
-- une liste d'élements mobiles
-- liste des états possibles de chaque élément mobile
+- `statique` une liste d'élements mobiles
+- `statique` liste des états possibles de chaque élément mobile
 
 ## Opérations possibles
 

--- a/content/developers/internals/simulation-model/ordering.md
+++ b/content/developers/internals/simulation-model/ordering.md
@@ -5,6 +5,11 @@ weight: 55
 description: "Décide de l'ordre de formation des itinéraires"
 ---
 
+{{% alert color="warning" %}}
+Cette page est une ébauche, contribuez-y!
+{{% /alert %}}
+
+
 ## Définition
 
 La couche d'ordonnancement a pour responsabilité d'établir l'ordre de commande des itinéraires, et par conséquent, l'ordre de passage des trains.

--- a/content/developers/internals/simulation-model/reservation.md
+++ b/content/developers/internals/simulation-model/reservation.md
@@ -5,6 +5,10 @@ weight: 30
 description: "Gère l'état de réservation des zones"
 ---
 
+{{% alert color="warning" %}}
+Le mot réservation ici a pour sens réservation de la resource itinéraire, et non le sens commande plannifiée d'itinéraire
+{{% /alert %}}
+
 ## Description
 
 Les zones (ou TVDSection / DetectionSection) sont des partitions physiques des voies :
@@ -28,67 +32,61 @@ Une zone avec une aiguille aura 4 configurations :
 **Chaque zone ne peut être réservée que pour une configuration donnée à la fois, mais peut être réservée simultanément par plusieurs routes**.
 Une zone ne peut changer de configuration que lorsqu'elle n'est pas réservée.
 
-L'enclanchement de transit est un enclanchement qui vise à empêcher le mouvement d'un appareil de voie lorsqu'un train est en approche.
-Il concerne les organes de commandes des aiguilles.
-un enclanchement est un système qui permet d'imposer des ordres de manoeuvre sur un système, soit imposer des interdictions
+{{% alert color="info" %}}
+En discutant avec des experts métiers, vont entendrez parler d'[enclenchements](https://fr.wikipedia.org/wiki/Enclenchement):
+le terme viens de l'époque où les postes de signalisations étaient entièrement mécaniques.
+Les enclanchements étaient alors des objets physiques qui empêchaient certaines configurations.
+
+Une conséquence de cet héritage historique et que beaucoup de règles ferroviaires sont exprimées par contraintes au lieu d'être exprimées par garanties.
+Aujourd'hui, un enclanchement, c'est une garantie qu'une situation particulière ne peut pas se produire.
+{{% /alert %}}
+
+
+### État dynamique d'une zone
+
+```rust
+enum ZoneState {
+    Free,
+    Reserved {
+        config: ZoneConfig,
+        trains: VecDeque<ZoneReservation>,
+    }
+}
+
+struct ZoneReservation {
+    train: TrainHandle,
+    status: ZoneReservationStatus,
+}
+
+enum ZoneReservationStatus {
+    /// In the process of being reserved, but not yet ready
+    PRE_RESERVED,
+    /// The train can arrive anytime
+    RESERVED,
+    /// The train is inside the zone
+    OCCUPIED,
+    /// The zone is pending release
+    PENDING_RELEASE,
+}
+```
 
 ## Exigences de conception
 
 - Les zones doivent pouvoir être **vérouillées** dans une configuration particulière.
 - Il doit être possible pour plusieurs routes de **partager une réservation** de configuration.
 - Il doit être possible d'observer l'**évolution de statut d'une réservation**.
-
-## État
-
-```python
-class ZoneReservationStatus(IntEnum):
-    # the head of the train didn't yet enter the zone
-    AWAITING_USE = auto()
-    # the train is inside the zone
-    IN_USE = auto() 
-    # the train went and left
-    AWAITING_RELEASE = auto()
-
-
-class ZoneReservation:
-    train: TrainHandle
-    status: ZoneReservationStatus
-
-    async def wait_for_status(self, status):
-        raise NotImplemented
-
-    async def release(self):
-        raise NotImplemented
-    
-
-class ZoneState:
-    # the current layout of the zone
-    configuration: ZoneConfiguration
-    # the list of trains which hold a right to use the zone in its current configuration
-    reservations: Set[TrainHandle]
-    # the list of trains currently inside the zone
-    occupation: Set[TrainHandle]
-
-    @property
-    def is_locked(self):
-        """When any train holds a reservation for a route, the zone cannot change configuration"""
-        return len(self.reservations) != 0
-
-    @abstractmethod
-    async def reserve(self, configuration) -> ZoneReservation:
-        raise NotImplemented
-```
+- Il doit être possible de faire évoluer le statut d'une réservation.
 
 ## Dépendances
 
-- une liste de zones
-- capacité d'observer l'occupation des zones
-- capacité d'actionner les éléments mobiles
+- `statique` une liste de zones
+- `dynamique` capacité d'observer l'occupation des zones
+- `dynamique` capacité d'actionner les éléments mobiles
 
 ## Opérations
 
-- **cantonnement**: Observer l'occupation de la zone
-- **cantonnement**: Observer la configuration de la zone (?)
-- **routage**: Réserver une configuration de zone
+- **espacement**: Observer l'état d'une zone
+- **routage**: Pré-réserver une configuration de zone
+- **routage**: Confirmer la réservation d'une zone
 - **routage**: Attendre que la réservation de la zone soit utilisée par son train
 - **routage**: Relacher une réservation de zone

--- a/content/developers/internals/simulation-model/signaling.md
+++ b/content/developers/internals/simulation-model/signaling.md
@@ -5,6 +5,10 @@ weight: 60
 description: "Gère l'état des signaux"
 ---
 
+{{% alert color="warning" %}}
+Cette page est une ébauche, contribuez-y!
+{{% /alert %}}
+
 
 ## Description
 

--- a/content/developers/internals/simulation-model/spacing.md
+++ b/content/developers/internals/simulation-model/spacing.md
@@ -7,41 +7,20 @@ description: "Gère l'état des cantons"
 
 ## Couche de cantonnement
 
-La couche de cantonnement gère des routes de signal à signal (canton).
-Elle permet à la signalisation d'observer l'état d'un groupe
-de zones protégées par chaque signal, et de trouver le signal
-suivant dans la chaîne.
+Les cantons sont l'équivalent des routes, mais pour la signalisation: les routes autorisent le déplacement du train, et les cantons, qui se superposent aux routes, permettent au train d'être mis au courant de ses mouvements autorisés.
 
-Chaque canton porte les informations statiques suivantes:
+Les cantons ont plusieurs attributs:
+ - un **chemin**, qui représente les zones protégées par le canton, et leur état attendu (au même format que le chemin des routes)
+ - un **signal d'entrée**, optionnel (quand le canton pars d'un butoir)
+ - des **signaux intermédiaires** éventuels (c'est utilisé avec des systèmes du style BAPR)
+ - un **signal de sortie**, optionnel (quand le canton se termine à un butoir)
 
-- les zones protégées par le canton, et leur configuration attendue (ce qui inclus l'état des éléments mobiles)
-- les signaux de début et de fin (optionnels)
+Le chemin est exprimé de détecteur en détecteur afin de pouvoir faire un rapprochement avec le graphe des routes.
 
-Un canton est **actif** si tous ses éléments mobiles sont dans la position requise.
-
-{{% alert title="TODO" color="warning" %}}
-Un canton devrait-il être actif quand toutes ses zones sont dans la configuration requise ? Dans ce cas, les cantons de sens contraire seront inactifs.
-{{% /alert %}}
-
-## État
-
-L'état du canton est une combinaison de:
-
-- si toutes les zones sont correctement réservées
-- si une des zones est occupée
-
-```rust
-struct SignalingRouteState {
-    reserved: bool,
-    occupied: bool,
-}
-```
-
-Les cantons n'ont pas d'état persistant. Ils sont à tout instant capables de recalculer leur état.
-
-## Opérations
-
-- On peut demander, étant une liste de signaling routes partant du même point, laquelle est **active** (si il y en a une), et son état. Cette opération est commune à la couche d'API, et non à une signaling route en particulier.
+Quelques remarques:
+- il peut y avoir plusieurs systèmes de signalisation superposés sur la même infrastructure. le modèle pars du principe qu'un seul système à la fois est actif
+- un canton n'a pas d'état: on peut se reposer sur l'état dynamique des zones qui le compose
+- les signaux utilisent les cantons pour savoir quelles zones sont à protéger à un instant donné
 
 ## Exigences de conception
 
@@ -49,3 +28,14 @@ Les cantons n'ont pas d'état persistant. Ils sont à tout instant capables de r
 - chaque signal doit connaître les **zones qu'il protège**
 - **compatibilité modules signalisation** : les modules doivent créer les cantons entre chaque signaux. Chaque canton a un système de signalisation associé.
 - **compatibilité pathfinding** : Le pathfinding se fait dans le produit du graphe de routage et du graphe de cantons.
+
+## Dépendances
+
+- `statique` les zones protégées par le canton, et leur configuration attendue (ce qui inclus l'état des éléments mobiles)
+- `statique` les signaux de début et de fin (optionnels)
+
+## Opérations
+
+- **signalisation**: étant donné une direction sur un détecteur, quel est le canton actif, s'il y en a un
+- **signalisation**: quel est le signal suivant dans la chaîne
+- **signalisation**: quelles sont les zones protégées par le signal


### PR DESCRIPTION
Following discussion with Christophe Mémin, the following changes were implemented:
 - the definition of the reservation state of zones was changed
 - the definition of routes was changed
 - the requirements for routes were changed
 - the concept of route entry was removed in favor of relying on zone states
 - the definition of spacing signaling route was changed: they now truly have no state, even temporary
 - operations were added to the spacing layer
 - general consistency work was undertaken

