### PR TITLE
Convert site to Hugo modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
 
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/DGEXSolutions/osrd-docsy

--- a/config.toml
+++ b/config.toml
@@ -10,8 +10,13 @@ enableMissingTranslationPlaceholders = true
 
 enableRobotsTXT = true
 
-# Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+# Hugo allows theme composition (and inheritance).
+[module]
+proxy = "direct"
+[[module.imports]]
+path = "github.com/google/docsy"
+[[module.imports]]
+path = "github.com/google/docsy/dependencies"
 
 # Will give values to .Lastmod etc.
 enableGitInfo = false
@@ -148,9 +153,6 @@ offlineSearch = true
 prism_syntax_highlighting = false
 
 [params.markmap]
-enable = true
-
-[params.mermaid]
 enable = true
 
 # User interface configuration

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/DGEXSolutions/osrd-website
+
+go 1.19
+
+require github.com/google/docsy v0.5.2-0.20221201174456-33f3dfe38463 // indirect
+
+// replace github.com/google/docsy v0.5.2-0.20221201174456-33f3dfe38463 => ../../docsy

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.5.2-0.20221201174456-33f3dfe38463 h1:LdL9EB6yxMI+WJKXDGoISrT70i2srvtt3I+htyeOj50=
+github.com/google/docsy v0.5.2-0.20221201174456-33f3dfe38463/go.mod h1:maoUAQU5H/d+FrZIB4xg1EVWAx7RyFMGSDJyWghm31E=
+github.com/google/docsy/dependencies v0.5.1/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.88.1"
+HUGO_VERSION = "0.107.0"


### PR DESCRIPTION
Use of docsy as submodule is not supported any more. This PR convert the OSRD site to Hugo modules.