### PR TITLE
contribute: Update contribute pages and add conventions

### DIFF
--- a/content/docs/guides/contribute/bug-reports.en.md
+++ b/content/docs/guides/contribute/bug-reports.en.md
@@ -7,6 +7,21 @@ description: "Report a bug or suggest an enhancement"
 
 **Please report anything you deem significant!**
 
-Our bug tracking platform is github, so have to register to report bugs.
+Our bug tracking platform is [github](https://github.com/DGEXSolutions/osrd/issues), so you have to register to report bugs.
 
 Follow [this link](https://github.com/DGEXSolutions/osrd/issues/new/choose) and pick whatever template fits the best.
+
+### Bugs
+
+- Bug must have a correct description and the bug's issue template must be filled carefully.
+- Bug must be tagged with (_for team members_):
+  - `kind:bug`
+  - one or several `area:<affected_area>` if possible, if the affected area is not known leave it blank it will be added later by another team member.
+  - one `severity:<bug_severity>` if possible, if severity is not known leave it blank it will be added later by another team member.
+    - `severity:minor`: User can still use the feature.
+    - `severity:major`: User sometimes can't use the feature.
+    - `severity:critical`: User can't use the feature.
+- OSRD team members can change issues' tags (severity, area, kind, ...).
+  You may leave a comment to explain changes.
+- If you are working on a bug or plan to work on a bug, assign yourself to the bug.
+- PRs solving bugs should add a regression tests to ensure that bug will not be back in the future.

--- a/content/docs/guides/contribute/code.en.md
+++ b/content/docs/guides/contribute/code.en.md
@@ -21,14 +21,13 @@ Most OSRD developers use Linux. Windows and MacOS should work too, but you may r
 
 For a long time, making changes to a component of a multi-service application involved compiling, configuring and running all services manually.
 
-Nowadays, it can be done using `docker-compose`. You can even start only a subset of the services.
+Nowadays, it can be done using `docker compose`. You can even start only a subset of the services.
 
-- Install `docker` and `docker-compose`. [^package-manager]
-- Run `docker-compose up --build`
+- Install `docker` and `docker compose`. [^package-manager]
+- Run `docker compose up --build`
 
 [^package-manager]: Under Linux, use your distribution's package manager, such as `apt-get`
 [^git-bash]: Under Windows, open `Git Bash`
-
 
 ## Share your changes
 
@@ -41,30 +40,48 @@ LGPLv3 forbids modifying source code without sharing the changes under the same 
 This constraint does not propagate through APIs: You can use OSRD as a library, framework or API server to interface with proprietary software. Please suggest changes if you need new interfaces.
 {{% /alert %}}
 
-
 This chapter is about the process of integrating changes into the common code base. **If you need help at any stage, open an issue or message us.**
 
-1) If you are not used to Git, [follow this tutorial](https://learngitbranching.js.org/)
+1. If you are not used to Git, [follow this tutorial](https://learngitbranching.js.org/)
 
-2) **Create a branch**  
-If you intend to contribute regularly, you can request access to the [main repository](https://github.com/DGEXSolutions/osrd). Otherwise, [create a fork](https://github.com/DGEXSolutions/osrd/fork).
+2. **Create a branch**  
+   If you intend to contribute regularly, you can request access to the [main repository](https://github.com/DGEXSolutions/osrd). Otherwise, [create a fork](https://github.com/DGEXSolutions/osrd/fork).
 
-3) **Add changes to your branch**  
-Before you start working, try to split your work into macroscopic steps. At the end of each stop, save your changes into a commit. Try to follow [style conventions](../conventions/).
+3. **Add changes to your branch**  
+   Before you start working, try to split your work into macroscopic steps.
+   At the end of each stop, save your changes into a commit.
+   Try to make commits of logical and atomic units.
+   Try to follow [style conventions](../conventions/).
 
-4) **Open a pull request**  
-Once your changes are ready, you have to request integration with the `dev` branch. It can be done through [the web interface](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+4. **Keep your branch up-to-date**
 
-5) **Take feedback into account**  
-Once your pull request is open, [other contributors can review your changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews):
+   ```
+   git switch <your_branch>
+   git fetch
+   git rebase origin/dev
+   ```
+
+5. **Open a pull request**  
+   Once your changes are ready, you have to request integration with the `dev` branch.
+   If possible, make PR of logical and atomic units too (avoid mixing refactoring, new features and bug fix at the same time).
+   Add a description to PRs to explain what they do and why.
+   Help the reviewer by following advice given in [mtlynch article](https://mtlynch.io/code-review-love/).
+   Add tags `Area:<affected_area>` to show which part of the application have been impacted.
+   It can be done through [the web interface](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+
+6. **Take feedback into account**  
+   Once your pull request is open, [other contributors can review your changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews):
+
    - Any user can review your changes
    - Your code has to be approved by a contributor [familiar with the code](https://github.com/DGEXSolutions/osrd/blob/dev/.github/CODEOWNERS)
-   - All users are expected to take critical comments into account
-   - Comments tend to be written in an open and direct manner. The intent is to efficiently collaborate towards a solution we all agree on.
+   - All users are expected to take comments into account.
+   - Comments tend to be written in an open and direct manner.
+     The intent is to efficiently collaborate towards a solution we all agree on.
    - Once all discussions are resolved, a maintainer integrates the change.
 
-6) **If you believe somebody forgot to review / merge your change, please speak out, multiple times if needs be.**
+   As a reviewer try to follow advice given in [mtlynch article](https://mtlynch.io/human-code-reviews-1/).
 
+7. **If you believe somebody forgot to review / merge your change, please speak out, multiple times if needs be.**
 
 ## Git commit style
 

--- a/content/docs/guides/contribute/conventions.en.md
+++ b/content/docs/guides/contribute/conventions.en.md
@@ -15,6 +15,10 @@ OSRD application is split in multiple services written in several languages. We 
 - Break work into digestible chunks.
 - Take the time to pick good names.
   Avoid non well-known abbreviations.
+- **Control and consistency over 3rd party code reuse**: Only add a dependency if it is absolutely necessary.
+  Every dependency we add decreases our autonomy and consistency.
+- **Don't re-invent every wheel**: As a counter to the previous point, don't re-invent everything at all costs.
+  If there is a dependency in the ecosystem that is the "de-facto" standard, we should heavily consider using it.
 - More code general recommendations in main repository [CONTRIBUTING.md](https://github.com/DGEXSolutions/osrd).
 - Ask for any help that you need!
 

--- a/content/docs/guides/contribute/conventions.en.md
+++ b/content/docs/guides/contribute/conventions.en.md
@@ -1,0 +1,71 @@
+---
+title: "Style guide"
+linkTitle: "Style guide"
+weight: 40
+description: "Coding style guide and best practices"
+---
+
+OSRD application is split in multiple services written in several languages. We try to follow general code best practices and follow specificity for each languages when required.
+
+## General rules
+
+- Explain what you're doing and why.
+- Document new code with doc comments.
+- Include clear, simple tests.
+- Break work into digestible chunks.
+- Take the time to pick good names.
+  Avoid non well-known abbreviations.
+- More code general recommendations in main repository [CONTRIBUTING.md](https://github.com/DGEXSolutions/osrd).
+- Ask for any help that you need!
+
+### Python
+
+Python code is used for some packages and integration testing.
+
+- Follow [the Zen of Python](https://www.python.org/dev/peps/pep-0020/).
+- Code is linted with [flake8](https://github.com/csachs/pyproject-flake8).
+- Code is formatted with [Black](https://github.com/psf/black).
+- Imports are sorted with [Isort](https://github.com/PyCQA/isort).
+- Python tests are written using [pytest](https://docs.pytest.org/).
+
+### Python
+
+- Use the [documentation example](https://doc.rust-lang.org/rust-by-example/meta/doc.html) to know how to phrase and format your documentation.
+- Code is linted with [clippy](https://github.com/rust-lang/rust-clippy).
+- Code is formatted with [fmt](https://github.com/rust-lang/rustfmt).
+- Rust code is tested files per files following these [recommendations](https://doc.rust-lang.org/book/ch11-01-writing-tests.html).
+
+### Rust
+
+- As a reference for our API development we are using the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/about.html).
+  Generally, these should be followed.
+- Prefer granular imports over glob imports like `diesel::*`.
+- Tests are written with the [built-in testing framework](https://doc.rust-lang.org/book/ch11-01-writing-tests.html).
+- Use the [documentation example](https://doc.rust-lang.org/rust-by-example/meta/doc.html) to know how to phrase and format your documentation.
+- Use consistent comment style:
+  - `///` doc comments belong above `#[derive(Trait)]` invocations.
+  - `//` comments should generally go above the line in question, rather than in-line.
+  - Start comments with capital letters. End them with a period if they are sentence-like.
+- Use comments to organize long and complex stretches of code that can't sensibly be refactored into separate functions.
+- Code is linted with [clippy](https://github.com/rust-lang/rust-clippy).
+- Code is formatted with [fmt](https://github.com/rust-lang/rustfmt).
+
+### Java
+
+- Code is formatted with [checkstyle](https://checkstyle.sourceforge.io/).
+
+### Javascript / Typescript / Front
+
+- When adding new files, write them in TypeScript as there is a goal to move to TypeScript.
+- Use generated endpoints from the `openapi.yaml` files to consume the backend.
+- Code is linted with [eslint](https://eslint.org/).
+- Code is formatted with [prettier](https://prettier.io/).
+- End-to-end tests are required for stable and critical features.
+  [Playwright](https://playwright.dev/) is used to write these tests.
+- To write unit test use [vitest](https://vitest.dev/).
+
+### Integration tests
+
+- Integration tests are written using [pytest](https://docs.pytest.org/) under the `/tests` folder.
+- Each route described in the `openapi.yaml` files must have an integration test.
+- Test must check both the valid and invalid response format and content.


### PR DESCRIPTION
Moving part of https://github.com/DGEXSolutions/osrd/pull/3347 in `conventions` file and completing current `contribute` pages.

:warning: I will do the translation in french once we are ok with the content :warning: 