### PR TITLE
decapcms: enable Signed-off-by in commit messages

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -7,6 +7,7 @@ backend:
     delete: 'news: delete "{{slug}}"'
     uploadMedia: 'news: upload media "{{path}}"'
     deleteMedia: 'news: delete media "{{path}}"'
+  signoff_commits: true
 site_url: "https://osrd.fr"
 media_folder: "static/images"
 public_folder: "/images"


### PR DESCRIPTION
Enable the new config option introduced in https://github.com/decaporg/decap-cms/pull/7766 and released in [DecapCMS v3.12][2].

[2]: https://github.com/decaporg/decap-cms/releases/tag/decap-cms%403.12.0