### PR TITLE
docs: add Railway Manager Interface API docs

### DIFF
--- a/content/docs/reference/apis/railway-manager-interface.en.md
+++ b/content/docs/reference/apis/railway-manager-interface.en.md
@@ -1,0 +1,7 @@
+---
+title: "Railway Manager Interface"
+type: page
+layout: swagger-ui
+params:
+  filename: railway_manager_interface/openapi.yaml
+---

--- a/content/docs/reference/apis/railway-manager-interface.fr.md
+++ b/content/docs/reference/apis/railway-manager-interface.fr.md
@@ -1,0 +1,7 @@
+---
+title: "Railway Manager Interface"
+type: page
+layout: swagger-ui
+params:
+  filename: railway_manager_interface/openapi.yaml
+---


### PR DESCRIPTION
Same as editoast/gateway docs, but for Railway Manager Interface.